### PR TITLE
Fix login errors in MacOS

### DIFF
--- a/KlasPlugin/src/js/master.js
+++ b/KlasPlugin/src/js/master.js
@@ -164,7 +164,7 @@ const login = (user_id, user_pw, callback) => {
         url: base_url
     }, (win) => {
         if (['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'].indexOf(window.navigator.platform) != -1) {
-            chrome.windows.update(window.id, {
+            chrome.windows.update(win.id, {
                 focused: true
             })
         }


### PR DESCRIPTION
Related with: #1  #2 

<img width="790" alt="image" src="https://user-images.githubusercontent.com/25397908/180830041-c361de6f-b5c0-4542-b30a-f6393babb99d.png">

In my environment, `window.id` just return `undefined` instead of any id, causes error.

I just changed `window.id` to `win.id` and it works.

Here my environment for Reference:
```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
System Software Overview:
      System Version: macOS 12.4 (21F79)
      Kernel Version: Darwin 21.5.0
```